### PR TITLE
Adjust shared element transition code to run on iOS as well

### DIFF
--- a/transitions/app/MaterialSharedElementTransitioner.js
+++ b/transitions/app/MaterialSharedElementTransitioner.js
@@ -111,14 +111,12 @@ class MaterialSharedElementTransitioner extends Component {
     }
     render() {
         return (
-            <View style={{ flex: 1 }} onLayout={this._onLayout.bind(this)}>
-                <Transitioner
-                    configureTransition={this._configureTransition.bind(this)}
-                    render={this._render.bind(this)}
-                    navigationState={this.props.navigation.state}
-                    style={this.props.style}
-                    />
-            </View>
+            <Transitioner
+                configureTransition={this._configureTransition.bind(this)}
+                render={this._render.bind(this)}
+                navigationState={this.props.navigation.state}
+                style={this.props.style}
+            />
         );
     }
     _configureTransition() {
@@ -293,8 +291,8 @@ class MaterialSharedElementTransitioner extends Component {
         const containerStyle = this._getOverlayContainerStyle(props.progress);
         return (
             <Animated.View style={[styles.overlay, this.props.style, containerStyle]}>
-                {sharedElements}
                 {this._renderFakedSEContainer(pairs, props, prevProps)}
+                {sharedElements}
             </Animated.View>
         );
     }
@@ -323,7 +321,9 @@ class MaterialSharedElementTransitioner extends Component {
         const navigation = this._getChildNavigation(scene);
 
         return (
-            <Animated.View key={transitionProps.scene.route.key} style={[style, styles.scene]}>
+            <Animated.View key={transitionProps.scene.route.key} style={[style, styles.scene]}
+                onLayout={this._onLayout.bind(this)}
+            >
                 <Scene navigation={navigation} />
                 {this._renderDarkeningOverlay(progress, position, index)}
             </Animated.View>

--- a/transitions/app/MaterialSharedElementTransitioner.js
+++ b/transitions/app/MaterialSharedElementTransitioner.js
@@ -214,7 +214,7 @@ class MaterialSharedElementTransitioner extends Component {
         });
     }
     _renderFakedSEContainer(pairs, props, prevProps) {
-        if (!prevProps) return null;
+        if (!prevProps || pairs.length === 0) return null;
 
         const fromItemBBox = this._getBBox(pairs.map(p => p.fromItem.metrics));
         const toItemBBox = this._getBBox(pairs.map(p => p.toItem.metrics));

--- a/transitions/app/PhotoDetail.js
+++ b/transitions/app/PhotoDetail.js
@@ -9,10 +9,10 @@ import {
     Dimensions,
     Text,
     Easing,
-    TouchableNativeFeedback,
 } from 'react-native';
 
 import SharedView from './SharedView';
+import Touchable from './Touchable';
 
 const { width: windowWidth } = Dimensions.get("window");
 
@@ -21,13 +21,13 @@ const PhotoDetail = (props) => {
     return (
         <ScrollView>
             <View>
-                <TouchableNativeFeedback onPress={() => props.onPhotoPressed(props.photo)}>
+                <Touchable onPress={() => props.onPhotoPressed(props.photo)}>
                     <View>
                         <SharedView name={`image-${url}`} containerRouteName='ROUTE_PHOTO_DETAIL'>
                             <Image source={image} style={styles.image} />
                         </SharedView>
                     </View>
-                </TouchableNativeFeedback>
+                </Touchable>
                 <SharedView name={`title-${url}`} containerRouteName='ROUTE_PHOTO_DETAIL'>
                     <Text style={[styles.text, styles.title]}>{title}</Text>
                 </SharedView>

--- a/transitions/app/PhotoDetail.js
+++ b/transitions/app/PhotoDetail.js
@@ -1,5 +1,5 @@
 // @flow
-import React, {Component} from 'react';
+import React, { Component } from 'react';
 import {
     View,
     ScrollView,
@@ -13,6 +13,7 @@ import {
 
 import SharedView from './SharedView';
 import Touchable from './Touchable';
+import Toolbar from './Toolbar';
 
 const { width: windowWidth } = Dimensions.get("window");
 
@@ -21,21 +22,24 @@ const PhotoDetail = (props) => {
     const { url, title, description, image } = photo;
     const openMoreDetails = photo => props.navigation.navigate('PhotoMoreDetail', { photo });
     return (
-        <ScrollView>
-            <View>
-                <Touchable onPress={() => openMoreDetails(photo) }>
-                    <View>
-                        <SharedView name={`image-${url}`} containerRouteName='PhotoDetail'>
-                            <Image source={image} style={styles.image} />
-                        </SharedView>
-                    </View>
-                </Touchable>
-                <SharedView name={`title-${url}`} containerRouteName='PhotoDetail'>
-                    <Text style={[styles.text, styles.title]}>{title}</Text>
-                </SharedView>
-                <Text style={[styles.text]}>{description}</Text>
-            </View>
-        </ScrollView>
+        <View>
+            <Toolbar navigation={props.navigation} />
+            <ScrollView>
+                <View>
+                    <Touchable onPress={() => openMoreDetails(photo)}>
+                        <View>
+                            <SharedView name={`image-${url}`} containerRouteName='PhotoDetail'>
+                                <Image source={image} style={styles.image} />
+                            </SharedView>
+                        </View>
+                    </Touchable>
+                    <SharedView name={`title-${url}`} containerRouteName='PhotoDetail'>
+                        <Text style={[styles.text, styles.title]}>{title}</Text>
+                    </SharedView>
+                    <Text style={[styles.text]}>{description}</Text>
+                </View>
+            </ScrollView>
+        </View>
     )
 };
 

--- a/transitions/app/PhotoGrid.js
+++ b/transitions/app/PhotoGrid.js
@@ -5,7 +5,6 @@ import {
     Image,
     View,
     Text,
-    TouchableNativeFeedback,
     Dimensions,
     StyleSheet,
 } from 'react-native';
@@ -13,6 +12,7 @@ import faker from 'faker';
 import _ from 'lodash';
 
 import SharedView from './SharedView';
+import Touchable from './Touchable';
 
 const ds = new ListView.DataSource({
     rowHasChanged: (r1, r2) => r1 !== r2,
@@ -66,13 +66,13 @@ class PhotoGrid extends Component {
     renderCell(photo) {
         const onPhotoPressed = this.props.onPhotoPressed;
         return (
-            <TouchableNativeFeedback onPress={() => onPhotoPressed(photo)} key={photo.url}>
+            <Touchable onPress={() => onPhotoPressed(photo)} key={photo.url}>
                 <View style={styles.cell}>
                     <SharedView name={`image-${photo.url}`} containerRouteName='ROUTE_PHOTO_GRID'>
                         <Image source={photo.image} style={styles.image}/>
                     </SharedView>
                 </View>
-            </TouchableNativeFeedback>
+            </Touchable>
         )
     }
 }

--- a/transitions/app/PhotoGridScreen.js
+++ b/transitions/app/PhotoGridScreen.js
@@ -31,6 +31,7 @@ class PhotoGridScreen extends Component {
         return (
             <View>
                 <Toolbar title={`${this.context.getActiveTransition()}`}
+                    navigation={this.props.navigation}
                     actions={toolbarActions}
                     onActionSelected={onActionSelected}
                     />

--- a/transitions/app/PhotoMoreDetail.js
+++ b/transitions/app/PhotoMoreDetail.js
@@ -13,25 +13,29 @@ import {
 } from 'react-native';
 
 import SharedView from './SharedView';
+import Toolbar from './Toolbar';
 
 const { width: windowWidth } = Dimensions.get("window");
 
 const PhotoMoreDetail = (props) => {
     const { photo: {url, title, description, image} } = props.navigation.state.params;
     return (
-        <ScrollView>
-            <View>
-                <View style={styles.container}>
-                    <SharedView name={`title-${url}`} containerRouteName='PhotoMoreDetail'>
-                        <Text style={[styles.text, styles.title]}>{title}</Text>
-                    </SharedView>
-                    <SharedView name={`image-${url}`} containerRouteName='PhotoMoreDetail'>
-                        <Image source={image} style={styles.image} />
-                    </SharedView>
+        <View>
+            <Toolbar navigation={props.navigation} />
+            <ScrollView>
+                <View>
+                    <View style={styles.container}>
+                        <SharedView name={`title-${url}`} containerRouteName='PhotoMoreDetail'>
+                            <Text style={[styles.text, styles.title]}>{title}</Text>
+                        </SharedView>
+                        <SharedView name={`image-${url}`} containerRouteName='PhotoMoreDetail'>
+                            <Image source={image} style={styles.image} />
+                        </SharedView>
+                    </View>
+                    <Text style={[styles.text]}>{description}</Text>
                 </View>
-                <Text style={[styles.text]}>{description}</Text>
-            </View>
-        </ScrollView>
+            </ScrollView>
+        </View>
     )
 };
 

--- a/transitions/app/Toolbar.js
+++ b/transitions/app/Toolbar.js
@@ -3,17 +3,29 @@
 import React from 'react';
 import {
     StyleSheet,
+    Platform,
+    View,
 } from 'react-native';
 
 import Icon from 'react-native-vector-icons/MaterialIcons';
 const {ToolbarAndroid} = Icon;
 
-const Toolbar = (props) => (
-    <ToolbarAndroid  
-        titleColor="white"
-        {...props}
-        style={[styles.toolbar, props.style]} />
-);
+// Don't show toolbar on iOS for now
+const ToolbarIos = (props) => (
+    <View {...props} />
+)
+
+const Toolbar = (props) => {
+    const Comp = (Platform.OS === 'android'
+        ? ToolbarAndroid
+        : ToolbarIos);
+    return (
+        <Comp
+            titleColor="white"
+            {...props}
+            style={[styles.toolbar, props.style]} />
+    )
+};
 
 const styles = StyleSheet.create({
     toolbar: {

--- a/transitions/app/Toolbar.js
+++ b/transitions/app/Toolbar.js
@@ -11,18 +11,20 @@ import {
 import Icon from 'react-native-vector-icons/MaterialIcons';
 const {ToolbarAndroid} = Icon;
 
-const ToolbarIos = (props) => (
-    <View {...props} style={{backgroundColor:'blue', paddingTop: 20}}>
-        {
-            (props.navigation.state
-                ? (
-                    <Button color="white" title="Back" onPress={() => props.navigation.goBack()}
+const ToolbarIos = (props) => {
+    return (
+        <View {...props} style={{ backgroundColor: 'blue', paddingTop: 20 }}>
+            {
+                (props.navigation.state.routeName !== 'PhotoGrid'
+                    ? (
+                        <Button color="white" title="Back" onPress={() => props.navigation.goBack()}
                         />
-                )
-                : null)
-        }
-    </View>
-)
+                    )
+                    : null)
+            }
+        </View>
+    )
+}
 
 const Toolbar = (props) => {
     const Comp = (Platform.OS === 'android'

--- a/transitions/app/Toolbar.js
+++ b/transitions/app/Toolbar.js
@@ -5,14 +5,23 @@ import {
     StyleSheet,
     Platform,
     View,
+    Button,
 } from 'react-native';
 
 import Icon from 'react-native-vector-icons/MaterialIcons';
 const {ToolbarAndroid} = Icon;
 
-// Don't show toolbar on iOS for now
 const ToolbarIos = (props) => (
-    <View {...props} />
+    <View {...props} style={{backgroundColor:'blue', paddingTop: 20}}>
+        {
+            (props.navigation.state
+                ? (
+                    <Button color="white" title="Back" onPress={() => props.navigation.goBack()}
+                        />
+                )
+                : null)
+        }
+    </View>
 )
 
 const Toolbar = (props) => {

--- a/transitions/app/Touchable.js
+++ b/transitions/app/Touchable.js
@@ -1,0 +1,15 @@
+import React from 'react';
+import {
+    TouchableNativeFeedback,
+    TouchableOpacity,
+    Platform,
+} from 'react-native';
+
+const Touchable = props => {
+    const Comp = (Platform.OS === 'android' 
+        ? TouchableNativeFeedback 
+        : TouchableOpacity);
+    return <Comp {...props} />
+} 
+
+export default Touchable;

--- a/transitions/index.ios.js
+++ b/transitions/index.ios.js
@@ -12,42 +12,14 @@ import {
   View
 } from 'react-native';
 
-export default class transitions extends Component {
+import App from './app/App';
+
+export default class Transitions extends Component {
   render() {
     return (
-      <View style={styles.container}>
-        <Text style={styles.welcome}>
-          Welcome to React Native!
-        </Text>
-        <Text style={styles.instructions}>
-          To get started, edit index.ios.js
-        </Text>
-        <Text style={styles.instructions}>
-          Press Cmd+R to reload,{'\n'}
-          Cmd+D or shake for dev menu
-        </Text>
-      </View>
+      <App />
     );
   }
 }
 
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    justifyContent: 'center',
-    alignItems: 'center',
-    backgroundColor: '#F5FCFF',
-  },
-  welcome: {
-    fontSize: 20,
-    textAlign: 'center',
-    margin: 10,
-  },
-  instructions: {
-    textAlign: 'center',
-    color: '#333333',
-    marginBottom: 5,
-  },
-});
-
-AppRegistry.registerComponent('transitions', () => transitions);
+AppRegistry.registerComponent('transitions', () => Transitions);


### PR DESCRIPTION
- Make the "transitions" project work on iOS
- Add a toolbar on each screen so we can go back on iOS
- Make Shared Element Transition work on iOS:
  - Measure in `onLayout` of each scene instead of at the root: https://github.com/lintonye/react-native-diary/pull/4/commits/984aa020c70184fcd71539f885a76b6334e2dc6e