### PR TITLE
Shared Element Transition: Aspect ratio and text size

### DIFF
--- a/transitions/app/MaterialSharedElementTransitioner.js
+++ b/transitions/app/MaterialSharedElementTransitioner.js
@@ -190,11 +190,18 @@ class MaterialSharedElementTransitioner extends Component {
                     { scaleX }, { scaleY }
                 ]
             };
-        }
+        };
 
         const animateFontSize = (itemFrom, itemTo) => {
-            return {};
-        }
+            // This requires the shared Text to have a "fontSize" prop that is the same as the style.
+            const getFontSize = element => (element.props && element.props.fontSize) || 12;
+            return {
+                fontSize: progress.interpolate({
+                    inputRange: [0, 1],
+                    outputRange: [getFontSize(itemFrom.reactElement), getFontSize(itemTo.reactElement)],
+                })
+            };
+        };
 
         const elementType = getElementType(itemFrom);
         let style;
@@ -207,7 +214,7 @@ class MaterialSharedElementTransitioner extends Component {
                 break;
             default:
                 style = animateScale(itemFrom, itemTo);
-        }
+        };
 
         const left = progress.interpolate({
             inputRange: [0, 1],

--- a/transitions/app/PhotoDetail.js
+++ b/transitions/app/PhotoDetail.js
@@ -34,7 +34,7 @@ const PhotoDetail = (props) => {
                         </View>
                     </Touchable>
                     <SharedView name={`title-${url}`} containerRouteName='PhotoDetail'>
-                        <Text style={[styles.text, styles.title]}>{title}</Text>
+                        <Text style={[styles.text, styles.title]} fontSize={35}>{title}</Text>
                     </SharedView>
                     <Text style={[styles.text]}>{description}</Text>
                 </View>
@@ -49,7 +49,7 @@ const styles = StyleSheet.create({
         height: windowWidth / 2,
     },
     title: {
-        fontSize: 25,
+        fontSize: 35,
         fontWeight: 'bold',
     },
     text: {

--- a/transitions/app/PhotoDetail.js
+++ b/transitions/app/PhotoDetail.js
@@ -46,7 +46,7 @@ const PhotoDetail = (props) => {
 const styles = StyleSheet.create({
     image: {
         width: windowWidth,
-        height: windowWidth,
+        height: windowWidth / 2,
     },
     title: {
         fontSize: 25,

--- a/transitions/app/PhotoMoreDetail.js
+++ b/transitions/app/PhotoMoreDetail.js
@@ -26,7 +26,7 @@ const PhotoMoreDetail = (props) => {
                 <View>
                     <View style={styles.container}>
                         <SharedView name={`title-${url}`} containerRouteName='PhotoMoreDetail'>
-                            <Text style={[styles.text, styles.title]}>{title}</Text>
+                            <Text style={[styles.text, styles.title]} fontSize={25}>{title}</Text>
                         </SharedView>
                         <SharedView name={`image-${url}`} containerRouteName='PhotoMoreDetail'>
                             <Image source={image} style={styles.image} />

--- a/transitions/app/SharedView.js
+++ b/transitions/app/SharedView.js
@@ -34,7 +34,7 @@ class SharedView extends Component {
         registerSharedView(new SharedItem(
             name,
             containerRouteName,
-            this.render(),
+            React.Children.only(this.props.children),
             nativeHandle,
         ));
     }


### PR DESCRIPTION
The previous implementation only works when the shared view is an Image and the aspect ratio of the Images on both from scene and to scene are the same.

- Animate width and height instead of scale, if the shared view is an Image
- Animate font size if the shared view is a Text
- For any other views, animate scaleX/Y. 
- Also use a simpler way to animate scale using `progress` instead of `position`